### PR TITLE
Fixed uncommenting line "spilling" to next line

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -416,6 +416,8 @@ Save in REGISTER or in the kill-ring with YANK-HANDLER."
               (/= beg (point-min))
               (=  (char-before beg) ?\n))
          (comment-or-uncomment-region (1- beg) end))
+        ((eq type 'line)
+           (comment-or-uncomment-region beg end)) 
         (t
          (let ((newpos (evilnc--extend-to-whole-comment beg end) ))
            (comment-or-uncomment-region (nth 0 newpos) (nth 1 newpos))


### PR DESCRIPTION
When there are adjacent lines to be uncommented, e.g.

```
;; foo
;; bar
```

and foo is uncommented using `evilnc-hotkey-comment-operator`, bar would also be uncommented.  The most likely explanation is that `end` passed in `(evilnc--extend-to-whole-comment beg end)` is on the next line.

Avoided this case by avoiding `evilnc--extend-to-whole-comment` when commenting/uncommenting lines.
