### PR TITLE
Prompt user for input and fix evilnc-kill-to-line

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -341,7 +341,7 @@ Paragraphs are separated by empty lines."
 ;;;###autoload
 (defun evilnc-comment-or-uncomment-to-the-line (&optional LINENUM)
   "Comment or uncomment from the current line to the LINENUM line"
-  (interactive "p")
+  (interactive "nLine: ")
   (if (not (region-active-p))
       (let ((b (line-beginning-position))
             (e (line-end-position)))
@@ -417,7 +417,7 @@ or 'C-u 3 M-x evilnc-quick-comment-or-uncomment-to-the-line' to comment to the l
    Case 2: If a region selected, the region is expand to make sure the region contain
    whole lines. Then we operate the expanded region. NUM is ignored.
 "
-  (interactive "p")
+  (interactive "NCopy and comment to line: ")
 
   ;; support negative number
   (when (< NUM 0)
@@ -439,7 +439,7 @@ or 'C-u 3 M-x evilnc-quick-comment-or-uncomment-to-the-line' to comment to the l
 ;;;###autoload
 (defun evilnc-copy-to-line (&optional LINENUM)
   "Copy from the current line to the LINENUM line, for non-evil user only"
-  (interactive "p")
+  (interactive "nCopy to line: ")
   (if (not (region-active-p))
       (let ((b (line-beginning-position))
             (e (line-end-position)))
@@ -455,7 +455,7 @@ or 'C-u 3 M-x evilnc-quick-comment-or-uncomment-to-the-line' to comment to the l
 ;;;###autoload
 (defun evilnc-kill-to-line (&optional LINENUM)
   "Kill from the current line to the LINENUM line, for non-evil user only"
-  (interactive "p")
+  (interactive "NKill to line: ")
   (if (not (region-active-p))
       (let ((b (line-beginning-position))
             (e (line-end-position)))
@@ -464,8 +464,8 @@ or 'C-u 3 M-x evilnc-quick-comment-or-uncomment-to-the-line' to comment to the l
           (if (< (line-beginning-position) b)
               (setq b (line-beginning-position)))
           (if (> (line-end-position) e)
-              (setq e (line-end-position)))
-          (kill-region b (+ 1 e)) ; +1 because we need remove the CR
+              (setq e (point-max)))
+          (kill-region b e)
           ))))
 
 ;;;###autoload


### PR DESCRIPTION
Prompt user input for following commands:
- evilnc-comment-or-uncomment-to-the-line
- evilnc-copy-to-line
- evilnc-copy-and-comment-lines
- evilnc-kill-to-line

If a prefix argument is supplied, then prompt won't appear.

Also fix evilnc-kill-to-the-line error when the extra newline at end of
file does not exist. For example, if line 8 is the last line and no
newline at the end, then kill to line 8 causes this error like this:

```
Args out of range: #<buffer *scratch*>, 192, 212
```

This PR is to fix this issue: https://github.com/redguardtoo/evil-nerd-commenter/issues/31
