### PR TITLE
Try to require evil when compiling

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -85,6 +85,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'evil nil :noerror))
+
 ;; Example, press ",,a{" will change C code:
 ;;   {printf("hello");} => /* {printf("hello");}*/
 ;; google "vim text object for more syntax"


### PR DESCRIPTION
Hi,

I've had problems with the evil part of evil-nerd-commenter for a while, getting the message that `evilnc-comment-operator` was undefined and I always worked around them by manually byte-compiling `evil-nerd-commenter.el`, sometimes twice. I've wanted to look into it for a while, but never got around to it.

This change fixes the situation for me. Passing the `noerror` argument to require is meant to keep evil-nerd-commenter from making evil a hard requirement. This doesn't help if people install evil-nerd-commenter first and then later add evil.

For a proper solution I would suggest looking into splitting the package in two, drastic as that may be. For example emacs-nerd-commenter and evil-nerd-commenter, where evil-nerd-commenter depends on both emacs-nerd-commenter and evil and emacs-nerd-commenter doesn't depend on anything.

This should help with #39 and possibly some others reporting the same problem.

Please let me know what you think, and if it helps.
