### PR TITLE
Comment operator should not be filling registers and kill-ring

### DIFF
--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -38,12 +38,6 @@
   "Comments text from BEG to END with TYPE.
 Save in REGISTER or in the kill-ring with YANK-HANDLER."
   (interactive "<R>")
-  (unless register
-    (let ((text (filter-buffer-substring beg end)))
-      (unless (string-match-p "\n" text)
-        ;; set the small delete register
-        (evil-set-register ?- text))))
-  (evil-yank beg end type register yank-handler)
   (cond
    ((eq type 'block)
     (let ((newpos (evilnc--extend-to-whole-comment beg end) ))

--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -34,10 +34,10 @@
 
 (require 'evil)
 
-(evil-define-operator evilnc-comment-operator (beg end type register yank-handler)
+(evil-define-operator evilnc-comment-operator (beg end type)
   "Comments text from BEG to END with TYPE.
 Save in REGISTER or in the kill-ring with YANK-HANDLER."
-  (interactive "<R><x><y>")
+  (interactive "<R>")
   (unless register
     (let ((text (filter-buffer-substring beg end)))
       (unless (string-match-p "\n" text)


### PR DESCRIPTION
Doesn't seem like the operator register and kill-ring features are used for evilnc, so take them out.  Typically, I don't need to paste just what I commented out, and if I do, I would use `evilnc-copy-and-comment-lines`.