### PR TITLE
Require cl at compile time

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -84,6 +84,8 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'cl))
+
 (defvar evilnc-invert-comment-line-by-line nil
   "If t then invert region comment status line by line.
 Please note it has NOT effect on evil text object!")


### PR DESCRIPTION
File uses `incf` and `decf` which depend on cl.
They're macros, so they're only needed at compile time.

If one happened to not have cl (say, if one has cl-lib instead) then executing the functions using `incf` and `decf` resulted in an error.