### PR TITLE
Remove byte-compiler error and some warnings

### DIFF
--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'evil)
+(require 'evil nil 'noerror)
 
 (evil-define-operator evilnc-comment-operator (beg end type)
   "Comments text from BEG to END with TYPE."
@@ -66,3 +66,7 @@
 (provide 'evil-nerd-commenter-operator)
 
 ;;; evil-nerd-commenter-operator.el ends here
+
+;; Local Variables:
+;; byte-compile-warnings: (not free-vars unresolved)
+;; End:

--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -293,6 +293,10 @@ See http://lists.gnu.org/archive/html/bug-gnu-emacs/2013-03/msg00891.html."
           (setq done t))
         ))))
 
+(defvar org-src-lang-modes)
+(declare-function org-show-subtree "org")
+(declare-function outline-up-heading "outline")
+
 (defun evilnc--working-on-region (beg end fn)
   "Region from BEG to END is applied with operation FN.
 Code snippets embedded in Org-mode is identified and right `major-mode' is used."
@@ -332,6 +336,9 @@ Code snippets embedded in Org-mode is identified and right `major-mode' is used.
       (org-show-subtree)
       (goto-char pos))
     ))
+
+(declare-function web-mode-comment-or-uncomment "ext:web-mode")
+(defvar web-mode-engine)
 
 (defun evilnc--warn-on-web-mode (is-comment)
   (let ((comment-operation (concat "web-mode-"
@@ -647,6 +654,8 @@ Then we operate the expanded region.  NUM is ignored."
   (interactive)
   (message "2.3"))
 
+(defvar evil-normal-state-map)
+(defvar evil-visual-state-map)
 ;;;###autoload
 (defun evilnc-default-hotkeys ()
   "Set the hotkeys of evil-nerd-comment."


### PR DESCRIPTION
Removes some byte compiler warnings, plus removes the error (in `evil-nerd-commenter-operator.el`) when compiling without evil already installed.

Unfortunately, without evil already installed, `evil-nerd-commenter-operator.el` still emits a few warnings due to the undefined macro. I don't know of an easy way to fix those without putting a `with-no-warnings` around the whole macro.
