### PR TITLE
copy-and-comment-operator

### DIFF
--- a/README.org
+++ b/README.org
@@ -197,6 +197,8 @@ Example 6: ",,w" comment to the beginning of the next word, ",,e" to the end of 
 
 Example 7: ",,it", comment the region inside html tags (all html major modes are supported , *including [[http://web-mode.org/][web-mode]]*)
 
+"evilnc-copy-and-comment-operator" is another evil-mode operator. Instead of commenting out the text in the operator-range, it inserts an copy of the text in the range and comments out that copy.
+
 * Tips
 ** Tip 1, Yank in evil-mode
 You can yank to line 99 using hotkey "y99G" or "y99gg". That's the feature from evil-mode.

--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -29,7 +29,7 @@
 ;;; Commentary:
 
 ;;
-;; Provides an operator for evil-mode.
+;; Provides operators for evil-mode.
 
 ;;; Code:
 
@@ -64,6 +64,17 @@
   (if (and (evil-called-interactively-p)
            (eq type 'line))
     (evil-first-non-blank)))
+
+(evil-define-operator evilnc-copy-and-comment-operator (beg end)
+  "Inserts an out commented copy of the text from BEG to END."
+  :move-point nil
+  (interactive "<r>")
+  (let ((p (point)))
+    (evil-yank-lines beg end nil 'lines)
+    (comment-region beg end)
+    (goto-char beg)
+    (evil-paste-before 1)
+    (goto-char p)))
 
 (provide 'evil-nerd-commenter-operator)
 ;;; evil-nerd-commenter-operator.el ends here


### PR DESCRIPTION
Introducing a new operator for copying to kill-ring, commenting and inserting with one action.
