### PR TITLE
Save position in org-mode src blocks.

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -312,7 +312,9 @@ Code snippets embedded in Org-mode is identified and right `major-mode' is used.
 
     (if evilnc-invert-comment-line-by-line
         (evilnc--invert-comment beg end)
-      (funcall fn beg end))
+      (setq pos (point))
+      (funcall fn beg end)
+      (goto-char pos))
 
     ;; turn off  3rd party language's major-mode temporarily and clean the shit
     (when lang-f


### PR DESCRIPTION
Currently, point jumps to the top of the src block when commenting. This seems to fix it.