### PR TITLE
Don't depend on evil mode.

### DIFF
--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -145,35 +145,37 @@
         (setq e (- e 1)))))
     e))
 
-(evil-define-text-object evilnc-inner-comment (&optional count begin end type)
-  "An inner comment text object."
-  (let* ((bounds (evilnc-get-comment-bounds)))
-    (cond
-     (bounds
-      (let* ((b (save-excursion
-                  (goto-char (car bounds))
-                  (forward-word 1)
-                  (forward-word -1)
-                  (point)))
-             (e (save-excursion
-                  (goto-char (cdr bounds))
-                  (goto-char (evilnc-ajusted-comment-end b (line-end-position)))
-                  (point))))
+(and (fboundp 'evil-define-text-object)
+     (evil-define-text-object evilnc-inner-comment (&optional count begin end type)
+       "An inner comment text object."
+       (let* ((bounds (evilnc-get-comment-bounds)))
+         (cond
+          (bounds
+           (let* ((b (save-excursion
+                       (goto-char (car bounds))
+                       (forward-word 1)
+                       (forward-word -1)
+                       (point)))
+                  (e (save-excursion
+                       (goto-char (cdr bounds))
+                       (goto-char (evilnc-ajusted-comment-end b (line-end-position)))
+                       (point))))
 
-        (evil-range b e 'block :expanded t)))
-     (t
-      (error "Not inside a comment.")))))
+             (evil-range b e 'block :expanded t)))
+          (t
+           (error "Not inside a comment."))))))
 
-(evil-define-text-object evilnc-outer-commenter (&optional count begin end type)
-  "An outer comment text object."
-  (let* ((bounds (evilnc-get-comment-bounds)))
-    (cond
-     (bounds
-      (let* ((b (car bounds))
-             (e (cdr bounds)))
-        (evil-range b e 'exclusive :expanded t)))
-     (t
-      (error "Not inside a comment.")))))
+(and (fboundp 'evil-define-text-object)
+     (evil-define-text-object evilnc-outer-commenter (&optional count begin end type)
+       "An outer comment text object."
+       (let* ((bounds (evilnc-get-comment-bounds)))
+         (cond
+          (bounds
+           (let* ((b (car bounds))
+                  (e (cdr bounds)))
+             (evil-range b e 'exclusive :expanded t)))
+          (t
+           (error "Not inside a comment."))))))
 
 (provide 'evil-nerd-commenter-operator)
 ;;; evil-nerd-commenter-operator.el ends here


### PR DESCRIPTION
Since the v3.0, the package happens to break the config of non-evil users of evil-nerd-commenter, because of the calls to `evil-define-text-object`.

This PR fixes that, avoiding the call when `(require 'evil)` fails.