### PR TITLE
Do not byte-compile evil-nerd-commenter-operator.el

### DIFF
--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -28,7 +28,7 @@
 
 ;;; Code:
 
-(require 'evil nil 'noerror)
+(require 'evil)
 (require 'evil-nerd-commenter-sdk)
 
 (defvar evilnc-c-style-comment-modes
@@ -209,5 +209,5 @@
 ;;; evil-nerd-commenter-operator.el ends here
 
 ;; Local Variables:
-;; byte-compile-warnings: (not free-vars unresolved)
+;; no-byte-compile: t
 ;; End:


### PR DESCRIPTION
Also, removed code that suppressed errors during byte compilation.

This change fixes a subtle bug that occurs when evil *is not* loaded when the
package is being installed/compiled, but *is* loaded when the package is being
used. This bug affected Spacemacs users:
* bug report: syl20bnr/spacemacs#8483
* details: https://github.com/syl20bnr/spacemacs/issues/8483#issuecomment-324967260