### PR TITLE
Fix doc-string typo and length

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -109,7 +109,8 @@
 (autoload 'count-lines "simple")
 
 (defvar evilnc-original-above-comment-when-copy-and-comment nil
-  "Original text is above commentn using `evilnc-copy-and-comment-lines' and `evilnc-copy-and-comment-operator'.")
+  "Keep the original text above the commented copy, when using either:
+`evilnc-copy-and-comment-lines' or `evilnc-copy-and-comment-operator'.")
 
 (defvar evilnc-invert-comment-line-by-line nil
   "If t then invert region comment status line by line.


### PR DESCRIPTION
Fix "commentn" typo, and add a newline, to shorten
the doc-string length below 80 characters.