### PR TITLE
prefer org-src-lang-modes over language property of org src

### DIFF
--- a/evil-nerd-commenter-tests.el
+++ b/evil-nerd-commenter-tests.el
@@ -106,14 +106,30 @@
       (insert "* hello\n"
               "** world\n"
               "#+BEGIN_SRC python\n"
-              "def f():"
+              "def f():\n"
               "    print 'hello world'\n"
-              "    print 'bye wrold'\n"
+              "    print 'bye world'\n"
               "#+END_SRC\n")
       (org-mode)
       (goto-char (point-min))
       (re-search-forward "print 'hello world'")
       (setq lang-f (evilnc--org-lang-major-mode))
       (should (string= lang-f "python-mode")))))
+
+(ert-deftest evilnc-test-org-src-block-with-org-src-lang-modes ()
+  (let* (lang-f)
+    (with-temp-buffer
+      (insert "* hello\n"
+              "** world\n"
+              "#+BEGIN_SRC elisp\n"
+              "(defun f ()\n"
+              "  (princ 'hello world')\n"
+              "  (princ 'bye world'))\n"
+              "#+END_SRC\n")
+      (org-mode)
+      (goto-char (point-min))
+      (re-search-forward "(princ 'hello world'")
+      (setq lang-f (evilnc--org-lang-major-mode))
+      (should (string= lang-f "emacs-lisp-mode")))))
 
 (ert-run-tests-batch-and-exit)

--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -326,7 +326,9 @@ See http://lists.gnu.org/archive/html/bug-gnu-emacs/2013-03/msg00891.html."
 
        ;; Emacs 26.1
        ((fboundp 'org-element-at-point)
-        (setq lang (org-element-property :language (org-element-at-point))))))
+        (setq lang
+              (let ((lang (org-element-property :language (org-element-at-point))))
+                (or (cdr (assoc lang org-src-lang-modes)) lang))))))
     (when lang
       (setq lang (if (symbolp lang) (symbol-name lang) lang))
       (setq lang-f (intern (concat lang "-mode"))))


### PR DESCRIPTION
If language is in `org-src-lang-modes` list use it to get the mode name (even for emacs 26.1) else fall back to the language property.
Necessary for modes that don't correspond to the language name and src blocks that don't use the usual language name (see for example [emacs-jupyter](https://github.com/dzop/emacs-jupyter/issues/68).