### PR TITLE
Make evilnc-comment-and-copy-operator create only one undo entry

### DIFF
--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -148,6 +148,7 @@
   "Inserts an out commented copy of the text from BEG to END."
   :move-point (not evilnc-original-above-comment-when-copy-and-comment)
   (interactive "<r>")
+  (evil-with-single-undo
     (evil-yank-lines beg end nil 'lines)
     (cond
      (evilnc-original-above-comment-when-copy-and-comment
@@ -161,7 +162,7 @@
       (evil-paste-before 1)
       ;; actual comment operatio should happen at last
       ;; or else beg end will be screwed up
-      (comment-region beg end))))
+      (comment-region beg end)))))
 
 (defun evilnc-is-one-line-comment (b e)
   "Check whether text between B and E is one line comment."


### PR DESCRIPTION
At the moment, `evilnc-copy-and-comment-operator` creates two undo entries (one for the pasted text and one for the commenting), meaning a user has to press undo twice if they want to undo the operation.  I think it makes more sense to only add one undo entry.