### PR TITLE
Replace string feature with symbol

### DIFF
--- a/evil-nerd-commenter.el
+++ b/evil-nerd-commenter.el
@@ -945,7 +945,7 @@ Paragraphs are separated by empty lines."
 
 ;; Attempt to define the operator on first load.
 ;; Will only work if evil has been loaded
-(with-eval-after-load "evil"
+(with-eval-after-load 'evil
   (require 'evil-nerd-commenter-operator))
 
 (provide 'evil-nerd-commenter)


### PR DESCRIPTION
This is a minor optimization.

`(eval-after-load FILE FORM)`

When FILE is a string, eval-after-load will scan the path of every file that is loaded for a match for `FILE`, and will do so even after evil has been loaded.

When FILE is a symbol, you avoid this polling behavior. Instead, Emacs waits for a `(provide 'FILE)` to evaluate `FORM`, which is marginally more performant.