### PR TITLE
fix: do not overshoot [multi]line comment boundaries

### DIFF
--- a/evil-nerd-commenter-operator.el
+++ b/evil-nerd-commenter-operator.el
@@ -260,10 +260,10 @@ Or expand the region to contain whole lines."
       (while (not (evilnc-pure-comment-p e))
         (setq e (- e 1)))
 
-      (if (< b e) (setq rlt (cons b (1+ e)))))
+      (if (< b e) (setq rlt (cons b e))))
      (t
       ;; multi-line comment
-      (setq rlt (cons b (1+ e)))))
+      (setq rlt (cons b e))))
     rlt))
 
 (defun evilnc-adjusted-comment-end (b e)


### PR DESCRIPTION
When selecting inner/outer comments the final selection always overshoots by one char if the first line after the comment is non-blank:

<img width="320" height="148" alt="image" src="https://github.com/user-attachments/assets/47137c0a-f467-4954-864d-edf7d6bc6cc4" />

<img width="311" height="160" alt="image" src="https://github.com/user-attachments/assets/e4774616-5ddf-4c18-b159-e99f7b64dc55" />

 This contribution fix the issue:
<img width="310" height="161" alt="image" src="https://github.com/user-attachments/assets/37e0eac5-444b-4bc2-ba64-cdf21349f645" />

<img width="307" height="139" alt="image" src="https://github.com/user-attachments/assets/00d7a777-6808-4fb5-9341-2acbee3e16ef" />


Unless I missed the real reason why those extra characters where added to the boundary end.